### PR TITLE
Remove marmelab/universal.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ A curated list of awesome CSS frameworks, libraries and software.
 * [wesbos/aprilFools.css](https://github.com/wesbos/aprilFools.css) - Harmlessly goof up your co-workers browser and chrome dev tools
 * [christophery/pushy](https://github.com/christophery/pushy) - Pushy is a responsive off-canvas navigation menu using CSS transforms & transitions
 * [ethantw/Han](https://github.com/ethantw/Han) - 「漢字標準格式」印刷品般的漢字排版框架 Han.css: the CSS typography framework optimised for Hanzi.
-* [marmelab/universal.css](https://github.com/marmelab/universal.css) - The only CSS you will ever need
 * [chrisnager/ungrid](https://github.com/chrisnager/ungrid) - ungrid - the simplest responsive css grid
 * [mrcoles/markdown-css](https://github.com/mrcoles/markdown-css) - CSS for making regular HTML look like plain-text markdown.
 * [bwsewell/tablecloth](https://github.com/bwsewell/tablecloth) - A CSS and JS bootstrap to style and manipulate data tables


### PR DESCRIPTION
Marmelab developer here,

Universal.css was a joke.
Do not consider it as a serious CSS library, please.

It's explained on the [README](https://github.com/marmelab/universal.css).